### PR TITLE
Made GMSDeprecationMacros header public

### DIFF
--- a/GoogleMaps.xcodeproj/project.pbxproj
+++ b/GoogleMaps.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A72C2FA61F6A86DD0076B723 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B9EE03A51D9D8500003E7610 /* SystemConfiguration.framework */; };
-		A72C2FA81F6A87620076B723 /* GMSDeprecationMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = A72C2FA71F6A87620076B723 /* GMSDeprecationMacros.h */; };
+		A72C2FA81F6A87620076B723 /* GMSDeprecationMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = A72C2FA71F6A87620076B723 /* GMSDeprecationMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A72C2FAA1F6A88100076B723 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A72C2FA91F6A88100076B723 /* CoreTelephony.framework */; };
 		B9234B4D1D9E2C68001EE0B5 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = B9234B4C1D9E2C68001EE0B5 /* GoogleMaps.bundle */; };
 		B9EE03721D9D8429003E7610 /* GoogleMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = B9EE03701D9D8429003E7610 /* GoogleMaps.h */; settings = {ATTRIBUTES = (Public, ); }; };


### PR DESCRIPTION
In 2.4.0 a header was moved from GoogleMaps to GoogleMapsBase and I forgot to make the header public after adding it to Base in my last PR.